### PR TITLE
fix: bug with pandas >= 1.5.0 iteritems

### DIFF
--- a/draw_graph.py
+++ b/draw_graph.py
@@ -60,7 +60,7 @@ class DrawGraph:
         """
         Dessine les sillons sur le graphique.
         """
-        iter_df = self.df_sillons.iteritems()
+        iter_df = self.df_sillons.items()
         _, pk_col = next(iter_df)
 
         for label, x_col in iter_df:


### PR DESCRIPTION
Simple correction de bug.

Remplacement d'une fonction supprimée dans Pandas V2 : la fonction pandas.DataFrame.iteritems est dépressiée depuis la Pandas 1.5.0, elle est remplacée à comportement identique par pandas.DataFrame.items().
[https://pandas.pydata.org/pandas-docs/version/1.5/reference/api/pandas.DataFrame.iteritems.html](https://pandas.pydata.org/pandas-docs/version/1.5/reference/api/pandas.DataFrame.iteritems.html)

Merci pour ce beau projet :)